### PR TITLE
Add Countdown to hacking start and end to home screen.

### DIFF
--- a/app/src/main/java/com/cuhacking/app/home/data/HomeRepository.kt
+++ b/app/src/main/java/com/cuhacking/app/home/data/HomeRepository.kt
@@ -1,12 +1,27 @@
 package com.cuhacking.app.home.data
 
 import com.cuhacking.app.Database
+import com.cuhacking.app.R
 import com.cuhacking.app.data.CoroutinesDispatcherProvider
 import com.cuhacking.app.data.Result
 import com.cuhacking.app.data.api.ApiService
 import kotlinx.coroutines.withContext
+import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalDateTime
 import javax.inject.Inject
 
-class HomeRepository {
+class HomeRepository @Inject constructor() {
+    fun getCountdownTime() =
+        if (LocalDateTime.now().isBefore(LocalDateTime.of(2020, 1, 11, 10, 30))) {
+            LocalDateTime.of(2020, 1, 11, 10, 0)
+        } else {
+            LocalDateTime.of(2020, 1, 12, 10, 0)
+        }
 
+    fun getCountdownMessage() =
+        if (LocalDateTime.now().isBefore(LocalDateTime.of(2020, 1, 11, 10, 30))) {
+            R.string.countdown_hack_start
+        } else {
+            R.string.countdown_hack_end
+        }
 }

--- a/app/src/main/java/com/cuhacking/app/home/domain/GetHomeCardsUseCase.kt
+++ b/app/src/main/java/com/cuhacking/app/home/domain/GetHomeCardsUseCase.kt
@@ -3,6 +3,8 @@ package com.cuhacking.app.home.domain
 import com.cuhacking.app.Database
 import com.cuhacking.app.R
 import com.cuhacking.app.data.CoroutinesDispatcherProvider
+import com.cuhacking.app.home.data.HomeRepository
+import com.cuhacking.app.ui.cards.CountdownCard
 import com.cuhacking.app.ui.cards.Header
 import com.cuhacking.app.ui.cards.Title
 import com.cuhacking.app.ui.cards.UpdateCard
@@ -13,7 +15,8 @@ import javax.inject.Inject
 
 class GetHomeCardsUseCase @Inject constructor(
     private val database: Database,
-    private val dispatchers: CoroutinesDispatcherProvider
+    private val dispatchers: CoroutinesDispatcherProvider,
+    private val repository: HomeRepository
 ) {
     operator fun invoke() =
         database.announcementQueries.getAll().asFlow().mapToList(dispatchers.io)
@@ -34,6 +37,11 @@ class GetHomeCardsUseCase @Inject constructor(
                     it
                 }
             }.map {
-                listOf(Title()) + it
+                listOf(
+                    CountdownCard(
+                        repository.getCountdownMessage(),
+                        repository.getCountdownTime()
+                    )
+                ) + it
             }
 }

--- a/app/src/main/java/com/cuhacking/app/ui/cards/Card.kt
+++ b/app/src/main/java/com/cuhacking/app/ui/cards/Card.kt
@@ -3,6 +3,8 @@ package com.cuhacking.app.ui.cards
 import android.annotation.SuppressLint
 import androidx.annotation.StringRes
 import androidx.recyclerview.widget.DiffUtil
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.ZonedDateTime
 
 sealed class Card {
     abstract infix fun sameAs(other: Card): Boolean
@@ -22,6 +24,7 @@ sealed class Card {
 
 data class Header(@StringRes val title: Int) : Card() {
     override fun sameAs(other: Card): Boolean = (other as? Header)?.title == title
+
     companion object {
         const val viewType = 1
     }
@@ -29,13 +32,19 @@ data class Header(@StringRes val title: Int) : Card() {
 
 class Title : Card() {
     override fun sameAs(other: Card): Boolean = true
+
     companion object {
         const val viewType = 8
     }
 }
 
-data class CountdownCard(private val timeString: String) : Card() {
-    override fun sameAs(other: Card): Boolean = false
+data class CountdownCard(@StringRes val message: Int, val time: LocalDateTime) : Card() {
+    override fun sameAs(other: Card): Boolean = (other as? CountdownCard)?.time == time
+
+    companion object {
+        const val viewType = 11
+
+    }
 }
 
 data class UpdateCard(
@@ -45,12 +54,13 @@ data class UpdateCard(
     val publishTime: Long
 ) : Card() {
     override fun sameAs(other: Card): Boolean = (other as? UpdateCard)?.id == id
+
     companion object {
         const val viewType = 2
     }
 }
 
-data class WiFiCard(val ssid: String, val password: String): Card() {
+data class WiFiCard(val ssid: String, val password: String) : Card() {
     override fun sameAs(other: Card): Boolean = (other as? WiFiCard)?.ssid == ssid
 
     companion object {

--- a/app/src/main/java/com/cuhacking/app/ui/cards/CardAdapter.kt
+++ b/app/src/main/java/com/cuhacking/app/ui/cards/CardAdapter.kt
@@ -12,6 +12,7 @@ class CardAdapter(private val viewModel: InfoViewModel? = null) :
             UpdateCard.viewType -> UpdateCardHolder(parent)
             WiFiCard.viewType -> WiFiCardHolder(parent, viewModel!!)
             Title.viewType -> TitleViewHolder(parent)
+            CountdownCard.viewType -> CountdownViewHolder(parent)
             else -> throw IllegalArgumentException("Unknown card type")
         }
     }
@@ -21,6 +22,7 @@ class CardAdapter(private val viewModel: InfoViewModel? = null) :
         is UpdateCard -> UpdateCard.viewType
         is WiFiCard -> WiFiCard.viewType
         is Title -> Title.viewType
+        is CountdownCard -> CountdownCard.viewType
         else -> 0
     }
 
@@ -30,6 +32,14 @@ class CardAdapter(private val viewModel: InfoViewModel? = null) :
             is UpdateCardHolder -> holder.bind(getItem(position) as UpdateCard)
             is WiFiCardHolder -> holder.bind(getItem(position) as WiFiCard)
             is TitleViewHolder -> holder.bind(getItem(position) as Title)
+            is CountdownViewHolder -> holder.bind(getItem(position) as CountdownCard)
+        }
+    }
+
+    override fun onViewRecycled(holder: CardViewHolder<*>) {
+        super.onViewRecycled(holder)
+        if (holder is CountdownViewHolder) {
+            holder.recycle()
         }
     }
 }

--- a/app/src/main/java/com/cuhacking/app/ui/cards/CardViewHolder.kt
+++ b/app/src/main/java/com/cuhacking/app/ui/cards/CardViewHolder.kt
@@ -2,17 +2,26 @@ package com.cuhacking.app.ui.cards
 
 import android.content.Intent
 import android.os.Build
+import android.os.CountDownTimer
 import android.provider.Settings
 import android.text.format.DateUtils
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.cardview.widget.CardView
 import androidx.recyclerview.widget.RecyclerView
 import com.cuhacking.app.R
 import com.cuhacking.app.info.data.WifiInfo
 import com.cuhacking.app.info.ui.InfoViewModel
 import com.google.android.material.button.MaterialButton
+import org.threeten.bp.Duration
+import org.threeten.bp.Instant
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.temporal.ChronoUnit
+import org.threeten.bp.temporal.TemporalUnit
+import kotlin.math.floor
 
 sealed class CardViewHolder<T : Card>(item: View) : RecyclerView.ViewHolder(item) {
     abstract fun bind(value: T)
@@ -86,5 +95,51 @@ class TitleViewHolder(parent: ViewGroup) : CardViewHolder<Title>(
     )
 ) {
     override fun bind(value: Title) {
+    }
+}
+
+class CountdownViewHolder(parent: ViewGroup) : CardViewHolder<CountdownCard>(
+    LayoutInflater.from(parent.context).inflate(
+        R.layout.header_announcement,
+        parent,
+        false
+    )
+) {
+
+    private lateinit var timer: CountDownTimer
+
+    override fun bind(value: CountdownCard) {
+        timer = object :
+            CountDownTimer(Duration.between(LocalDateTime.now(), value.time).toMillis(), 1000) {
+            override fun onTick(millisUntilFinished: Long) {
+                val hours = floor(millisUntilFinished / 60 / 60 / 1000f).toInt()
+                val minutes = floor((millisUntilFinished - (hours * 60 * 60 * 1000L)) / 60 / 1000f).toInt()
+                val seconds = (floor(millisUntilFinished / 1000f)).toInt() % 60
+
+                val hourString = "$hours".padStart(2, '0')
+                val minuteString = "$minutes".padStart(2, '0')
+                val secondsString = "$seconds".padStart(2, '0')
+
+                itemView.findViewById<TextView>(R.id.title_text).text =
+                    itemView.context.getString(
+                        value.message,
+                        "${hourString}:${minuteString}:${secondsString}"
+                    )
+            }
+
+            override fun onFinish() {
+                itemView.findViewById<TextView>(R.id.title_text).text =
+                    itemView.context.getString(
+                        value.message,
+                        "00:00:00"
+                    )
+            }
+        }
+        timer.start()
+
+    }
+
+    fun recycle() {
+        timer.cancel()
     }
 }

--- a/app/src/main/res/layout/header_announcement.xml
+++ b/app/src/main/res/layout/header_announcement.xml
@@ -9,6 +9,7 @@
         android:paddingBottom="4dp">
 
     <TextView
+            android:id="@+id/title_text"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fontFamily="@font/reem_kufi"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,4 +31,7 @@
 
     <string name="wifi_network">Network: %1$s</string>
     <string name="wifi_password">Password: %1$s</string>
+
+    <string name="countdown_hack_start">Hacking begins in %1$s</string>
+    <string name="countdown_hack_end">Hacking ends in %1$s</string>
 </resources>

--- a/app/src/main/sqldelight/com/cuhacking/app/data/db/Announcement.sq
+++ b/app/src/main/sqldelight/com/cuhacking/app/data/db/Announcement.sq
@@ -8,13 +8,13 @@ CREATE TABLE announcement(
 );
 
 insert:
-INSERT INTO announcement VALUES(:id, :title, :descirption, :locationId, :deliveryTime, :eventId);
+INSERT INTO announcement VALUES(:id, :title, :description, :locationId, :deliveryTime, :eventId);
 
 delete:
 DELETE FROM announcement WHERE id = :id;
 
 getAll:
-SELECT * FROM announcement;
+SELECT * FROM announcement ORDER BY deliveryTime DESC;
 
 getById:
 SELECT * FROM announcement WHERE id = :id;


### PR DESCRIPTION
<!-- Please follow this template when posting a new PR. -->
### Branch 
countdown

### Trello Card

Second portion of splitting Home/Info screen which is to add Countdown for hacking start/end.
[224](https://trello.com/c/cnyRldMa/224-split-announcements-and-info-into-separate-pages)

### Description

Title now displays a countdown in HH:MM:SS to the beginning of hacking. Time is currently set to a rough hard-coded time but will be updated to match the actual start of hacking based on schedule data.

Fixed the order of announcements in SQL query. Sort by `DESC`.

![device-2019-12-16-220541](https://user-images.githubusercontent.com/6743693/70961587-3d87bd80-2050-11ea-9469-976a8b906121.png)

### Tests

Countdown displays correct time remaining to 10:00 AM January 11th, 2020. After then, the time remaining will display `00:00:00` (tested by setting destination time to yesterday).
