### PR TITLE
Add event details screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,11 @@ android {
     packagingOptions {
         exclude("META-INF/kotlinx-coroutines-core.kotlin_module")
     }
+
+    kotlinOptions {
+        this as org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+        jvmTarget = "1.8"
+    }
 }
 
 repositories {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,10 @@
         <activity android:name=".signin.ui.SignInActivity"></activity>
         <activity android:name=".admin.ui.AdminActivity"></activity>
         <activity android:name=".profile.ui.ProfileActivity"></activity>
-        <activity android:name=".ui.MainActivity"></activity> <!-- Use an alias in order to avoid breaking home screen shortcuts when updated from previous version of app. -->
+        <activity android:name=".ui.MainActivity"></activity>
+        <activity android:name=".schedule.ui.EventDetailActivity"></activity>
+
+        <!-- Use an alias in order to avoid breaking home screen shortcuts when updated from previous version of app. -->
         <activity-alias
                 android:name=".ui.MainActivity"
                 android:targetActivity=".ui.MainActivity">

--- a/app/src/main/java/com/cuhacking/app/di/CoreComponent.kt
+++ b/app/src/main/java/com/cuhacking/app/di/CoreComponent.kt
@@ -22,6 +22,7 @@ import com.cuhacking.app.home.ui.HomeViewModel
 import com.cuhacking.app.info.ui.InfoViewModel
 import com.cuhacking.app.map.ui.MapViewModel
 import com.cuhacking.app.profile.ui.ProfileViewModel
+import com.cuhacking.app.schedule.ui.EventDetailViewModel
 import com.cuhacking.app.schedule.ui.ScheduleViewModel
 import com.cuhacking.app.signin.ui.SignInViewModel
 import dagger.BindsInstance
@@ -47,7 +48,7 @@ interface CoreComponent {
     fun signInViewModelFactory(): ViewModelFactory<SignInViewModel>
     fun infoViewModelFactory(): ViewModelFactory<InfoViewModel>
     fun scheduleViewModelFactory(): ViewModelFactory<ScheduleViewModel>
-
+    fun eventDetailViewModelFactory(): ViewModelFactory<EventDetailViewModel>
     fun homeViewModelFactory(): ViewModelFactory<HomeViewModel>
 
     fun inject(application: CuHackingApplication)

--- a/app/src/main/java/com/cuhacking/app/schedule/data/models/EventDetailUiModel.kt
+++ b/app/src/main/java/com/cuhacking/app/schedule/data/models/EventDetailUiModel.kt
@@ -1,0 +1,10 @@
+package com.cuhacking.app.schedule.data.models
+
+data class EventDetailUiModel(
+    val id: String,
+    val title: String,
+    val timeDuration: String,
+    val locationName: String,
+    val category: String,
+    val description: String
+)

--- a/app/src/main/java/com/cuhacking/app/schedule/domain/GetEventDetailUseCase.kt
+++ b/app/src/main/java/com/cuhacking/app/schedule/domain/GetEventDetailUseCase.kt
@@ -1,0 +1,45 @@
+package com.cuhacking.app.schedule.domain
+
+import com.cuhacking.app.Database
+import com.cuhacking.app.data.CoroutinesDispatcherProvider
+import com.cuhacking.app.schedule.data.models.EventDetailUiModel
+import com.squareup.sqldelight.runtime.coroutines.asFlow
+import com.squareup.sqldelight.runtime.coroutines.mapToOneOrNull
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.threeten.bp.Instant
+import org.threeten.bp.ZoneOffset
+import org.threeten.bp.ZonedDateTime
+import org.threeten.bp.format.DateTimeFormatter
+import javax.inject.Inject
+
+class GetEventDetailUseCase @Inject constructor(
+    private val database: Database,
+    private val dispatchers: CoroutinesDispatcherProvider
+) {
+    private val timeFormatter = DateTimeFormatter.ofPattern("h:mm a")
+
+    operator fun invoke(id: String): Flow<EventDetailUiModel?> =
+        database.eventQueries.getById(id).asFlow().mapToOneOrNull(dispatchers.io)
+            .map { event ->
+                event ?: return@map null
+
+                val startTime = ZonedDateTime.ofInstant(
+                    Instant.ofEpochSecond(event.startTime / 1000),
+                    ZoneOffset.UTC
+                )
+                val endTime = ZonedDateTime.ofInstant(
+                    Instant.ofEpochSecond(event.endTime / 1000),
+                    ZoneOffset.UTC
+                )
+
+                return@map EventDetailUiModel(
+                    event.id,
+                    event.title,
+                    "${timeFormatter.format(startTime)} - ${timeFormatter.format(endTime)}",
+                    event.locationName,
+                    event.type,
+                    event.description
+                )
+            }
+}

--- a/app/src/main/java/com/cuhacking/app/schedule/ui/EventDetailActivity.kt
+++ b/app/src/main/java/com/cuhacking/app/schedule/ui/EventDetailActivity.kt
@@ -1,0 +1,57 @@
+package com.cuhacking.app.schedule.ui
+
+import android.os.Bundle
+import android.view.Menu
+
+import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import androidx.navigation.findNavController
+import androidx.navigation.navArgs
+import com.cuhacking.app.R
+import com.cuhacking.app.di.injector
+import com.cuhacking.app.schedule.data.models.EventDetailUiModel
+import kotlinx.android.synthetic.main.activity_schedule_detail.*
+
+class EventDetailActivity : AppCompatActivity(R.layout.activity_schedule_detail) {
+    private val viewModel: EventDetailViewModel by viewModels { injector.eventDetailViewModelFactory() }
+    private val args by navArgs<EventDetailActivityArgs>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        toolbar.setNavigationOnClickListener {
+            finish()
+        }
+
+        viewModel.init(args.eventId)
+        viewModel.details.observe(this, Observer {
+            when (it) {
+                null -> {
+                    Toast.makeText(
+                        this,
+                        getString(R.string.error_event_details),
+                        Toast.LENGTH_SHORT
+                    )
+                        .show()
+                    finish()
+                }
+                else -> updateUi(it)
+            }
+        })
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.event_detail, menu)
+        return super.onCreateOptionsMenu(menu)
+    }
+
+    private fun updateUi(model: EventDetailUiModel) {
+        event_title.text = model.title
+        event_time.text = model.timeDuration
+        event_location_name.text = model.locationName
+        event_type_name.text = model.category
+        event_summary.text = model.description
+    }
+}

--- a/app/src/main/java/com/cuhacking/app/schedule/ui/EventDetailViewModel.kt
+++ b/app/src/main/java/com/cuhacking/app/schedule/ui/EventDetailViewModel.kt
@@ -1,0 +1,25 @@
+package com.cuhacking.app.schedule.ui
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.cuhacking.app.schedule.data.models.EventDetailUiModel
+import com.cuhacking.app.schedule.domain.GetEventDetailUseCase
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class EventDetailViewModel @Inject constructor(
+    private val getEventDetail: GetEventDetailUseCase
+) : ViewModel() {
+
+    private val _details = MutableLiveData<EventDetailUiModel?>()
+    val details: LiveData<EventDetailUiModel?> = _details
+
+    fun init(eventId: String) = viewModelScope.launch {
+        getEventDetail(eventId).collect {
+            _details.postValue(it)
+        }
+    }
+}

--- a/app/src/main/java/com/cuhacking/app/schedule/ui/ScheduleAdapter.kt
+++ b/app/src/main/java/com/cuhacking/app/schedule/ui/ScheduleAdapter.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.navigation.NavController
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.cuhacking.app.R
@@ -12,9 +13,18 @@ import com.cuhacking.app.schedule.data.models.EventUiModel
 import com.google.android.material.card.MaterialCardView
 import org.threeten.bp.format.DateTimeFormatter
 
-class ScheduleAdapter :
+class ScheduleAdapter(private val nav: NavController) :
     ListAdapter<EventUiModel, ScheduleAdapter.ViewHolder>(EventUiModel.DIFF_CALLBACK) {
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        init {
+            itemView.setOnClickListener {
+                val directions = ScheduleFragmentDirections.actionScheduleToEventDetailActivity(
+                    getItem(adapterPosition).id
+                )
+                nav.navigate(directions)
+            }
+        }
+
         fun bind(model: EventUiModel) {
             itemView.findViewById<TextView>(R.id.title).text = model.title
             itemView.findViewById<TextView>(R.id.location).text = model.locationName

--- a/app/src/main/java/com/cuhacking/app/schedule/ui/ScheduleFragment.kt
+++ b/app/src/main/java/com/cuhacking/app/schedule/ui/ScheduleFragment.kt
@@ -21,6 +21,7 @@ import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.cuhacking.app.R
 import com.cuhacking.app.di.injector
@@ -34,7 +35,7 @@ class ScheduleFragment : Fragment(R.layout.schedule_fragment) {
 
     private val viewModel: ScheduleViewModel by viewModels { injector.scheduleViewModelFactory() }
 
-    private val scheduleAdapter by lazy { ScheduleAdapter() }
+    private val scheduleAdapter by lazy { ScheduleAdapter(findNavController()) }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/app/src/main/res/drawable/ic_back.xml
+++ b/app/src/main/res/drawable/ic_back.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="?menuIconColor"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_link.xml
+++ b/app/src/main/res/drawable/ic_link.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M3.9,12c0,-1.71 1.39,-3.1 3.1,-3.1h4L11,7L7,7c-2.76,0 -5,2.24 -5,5s2.24,5 5,5h4v-1.9L7,15.1c-1.71,0 -3.1,-1.39 -3.1,-3.1zM8,13h8v-2L8,11v2zM17,7h-4v1.9h4c1.71,0 3.1,1.39 3.1,3.1s-1.39,3.1 -3.1,3.1h-4L13,17h4c2.76,0 5,-2.24 5,-5s-2.24,-5 -5,-5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_room.xml
+++ b/app/src/main/res/drawable/ic_room.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C8.13,2 5,5.13 5,9c0,5.25 7,13 7,13s7,-7.75 7,-13c0,-3.87 -3.13,-7 -7,-7zM12,11.5c-1.38,0 -2.5,-1.12 -2.5,-2.5s1.12,-2.5 2.5,-2.5 2.5,1.12 2.5,2.5 -1.12,2.5 -2.5,2.5z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_star.xml
+++ b/app/src/main/res/drawable/ic_star.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_star_border.xml
+++ b/app/src/main/res/drawable/ic_star_border.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M22,9.24l-7.19,-0.62L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21 12,17.27 18.18,21l-1.63,-7.03L22,9.24zM12,15.4l-3.76,2.27 1,-4.28 -3.32,-2.88 4.38,-0.38L12,6.1l1.71,4.04 4.38,0.38 -3.32,2.88 1,4.28L12,15.4z"/>
+</vector>

--- a/app/src/main/res/layout/activity_schedule_detail.xml
+++ b/app/src/main/res/layout/activity_schedule_detail.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:menu="@menu/event_detail"
+                app:navigationIcon="@drawable/ic_back" />
+
+        <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/event_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:fontFamily="@font/reem_kufi"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/toolbar"
+                tools:text="Workshop title goes here" />
+
+        <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/event_time"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="16dp"
+                android:fontFamily="@font/reem_kufi"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/event_title"
+                tools:text="1:15 PM - 2:00 PM" />
+
+        <ImageView
+                android:id="@+id/room_icon"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:alpha="0.8"
+                android:src="@drawable/ic_room"
+                android:tint="?android:attr/textColorHint"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/event_time" />
+
+        <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/event_location_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:fontFamily="@font/m_plus_1p"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
+                android:textColor="?android:attr/textColorSecondary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/room_icon"
+                app:layout_constraintTop_toBottomOf="@+id/event_time"
+                tools:text="Atrium" />
+
+        <ImageView
+                android:id="@+id/category_icon"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="18dp"
+                android:alpha="0.8"
+                android:src="@drawable/ic_food_group"
+                android:tint="?android:attr/textColorHint"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/event_location_name" />
+
+        <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/event_type_name"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:fontFamily="@font/m_plus_1p"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Subtitle2"
+                android:textColor="?android:attr/textColorSecondary"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/category_icon"
+                app:layout_constraintTop_toBottomOf="@+id/event_location_name"
+                tools:text="Workshop" />
+
+        <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/event_summary"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:fontFamily="@font/m_plus_1p"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+                android:textIsSelectable="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/event_type_name"
+                tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque eleifend elementum massa ut vehicula. Nam tincidunt non nunc in venenatis. Nam elit felis, bibendum pretium suscipit et, sollicitudin in mauris. Pellentesque feugiat elementum felis vitae aliquam. Nulla ac odio ac tortor feugiat fringilla. Suspendisse lobortis libero quis imperdiet suscipit. Sed mattis odio lacus, eget suscipit elit vulputate vel. Etiam augue nisl, elementum eu tristique et, dapibus eget justo. Nam condimentum interdum pretium. Cras semper mauris a rhoncus fermentum." />
+
+        <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/resources_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/event_summary"
+                android:fontFamily="@font/reem_kufi"
+                tools:text="Resources" />
+
+        <androidx.recyclerview.widget.RecyclerView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/resources_title" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/event_resource.xml
+++ b/app/src/main/res/layout/event_resource.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="64dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:foreground="?selectableItemBackground"
+        tools:targetApi="m">
+
+    <TextView
+            android:id="@+id/link_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body1"
+            app:layout_constraintBottom_toTopOf="@+id/link_url"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@+id/link_icon"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Workshop Starter Kit" />
+
+    <TextView
+            android:id="@+id/link_url"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
+            android:textColor="?android:attr/textColorSecondary"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@+id/link_icon"
+            app:layout_constraintTop_toBottomOf="@+id/link_title"
+            tools:text="https://github.com/cuhacking/cuHacking-android" />
+
+    <ImageView
+            android:id="@+id/link_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:srcCompat="@drawable/ic_link" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/event_detail.xml
+++ b/app/src/main/res/menu/event_detail.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+            android:id="@+id/favourite"
+            android:icon="@drawable/ic_star_border"
+            android:title="@string/event_add_favourite"
+            app:showAsAction="ifRoom"
+            app:iconTint="?menuIconColor"/>
+    <item
+            android:id="@+id/on_map"
+            android:icon="@drawable/ic_room"
+            android:title="@string/event_view_map"
+            app:showAsAction="ifRoom"
+            app:iconTint="?menuIconColor"/>
+</menu>

--- a/app/src/main/res/navigation/main.xml
+++ b/app/src/main/res/navigation/main.xml
@@ -25,7 +25,11 @@
     <fragment android:id="@+id/map" android:name="com.cuhacking.app.map.ui.MapFragment"
               android:label="@string/app_name" tools:layout="@layout/map_fragment"/>
     <fragment android:id="@+id/schedule" android:name="com.cuhacking.app.schedule.ui.ScheduleFragment"
-              android:label="@string/app_name" tools:layout="@layout/schedule_fragment"/>
+              android:label="@string/app_name" tools:layout="@layout/schedule_fragment">
+        <action
+                android:id="@+id/action_schedule_to_eventDetailActivity"
+                app:destination="@id/eventDetailActivity" />
+    </fragment>
     <activity android:id="@+id/admin" android:name="com.cuhacking.app.admin.ui.AdminActivity"
               android:label="activity_admin" tools:layout="@layout/activity_admin"/>
     <activity android:id="@+id/profile" android:name="com.cuhacking.app.profile.ui.ProfileActivity"
@@ -43,4 +47,12 @@
             android:id="@+id/home"
             android:name="com.cuhacking.app.home.ui.HomeFragment"
             android:label="@string/app_name" />
+    <activity
+            android:id="@+id/eventDetailActivity"
+            android:name="com.cuhacking.app.schedule.ui.EventDetailActivity"
+            android:label="EventDetailActivity" >
+        <argument
+                android:name="event_id"
+                app:argType="string" />
+    </activity>
 </navigation>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -9,6 +9,8 @@
         <item name="android:statusBarColor">?colorSurface</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">false</item>
         <item name="menuIconColor">?android:textColorPrimary</item>
+        <item name="android:navigationBarColor">#2D2D2D</item>
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
     </style>
 
     <style name="Widget.CuHacking.Card.Wifi" parent="Widget.MaterialComponents.CardView">
@@ -16,9 +18,9 @@
     </style>
 
     <style name="Widget.CuHacking.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">
-        <item name="android:background">?android:attr/colorBackground</item>
         <item name="titleTextColor">?android:textColorPrimary</item>
         <item name="android:elevation">4dp</item>
         <item name="android:titleTextStyle">@style/TextAppearance.CuHacking.ToolbarTitle</item>
     </style>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,4 +34,10 @@
 
     <string name="countdown_hack_start">Hacking begins in %1$s</string>
     <string name="countdown_hack_end">Hacking ends in %1$s</string>
+
+    <string name="error_event_details">Could not load event details</string>
+
+    <string name="event_add_favourite">Add to Favourites</string>
+    <string name="event_remove_favourite">Remove from Favourites</string>
+    <string name="event_view_map">View Location on Map</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,6 +25,7 @@
         <item name="android:statusBarColor">?colorSurface</item>
         <item name="android:windowLightStatusBar" tools:targetApi="m">true</item>
         <item name="menuIconColor">?colorPrimary</item>
+        <item name="android:navigationBarColor">#00000000</item>
     </style>
 
     <style name="Widget.CuHacking.Button.FloorSelectorButton" parent="Widget.MaterialComponents.Button.OutlinedButton">
@@ -37,7 +38,7 @@
 
     <style name="ThemeOverlay.CuHacking.Toolbar.Surface" parent="ThemeOverlay.MaterialComponents.Toolbar.Surface">
         <item name="android:textColorPrimary">?colorPrimary</item>
-        <item name="iconTint">?colorPrimary</item>
+        <item name="iconTint">?menuIconColor</item>
     </style>
 
     <style name="Widget.CuHacking.Toolbar" parent="Widget.MaterialComponents.Toolbar.Surface">


### PR DESCRIPTION
Loads data, has full layout

<!-- Please follow this template when posting a new PR. -->
### Branch 
event-detail

### Trello Card

https://trello.com/c/FJqbDPLW/225-implement-individual-event-detail-screen

### Description

Added details screen for events. Has the title, start/end times, location, type (though no type data is currently provided by the server), and summary. It also has the menu layout for adding an event to your favourites and for viewing it on the map.

The components for displaying Resources/external links are also included, but the server lacks this data so it is currently unfinished.

### Tests

Open schedule tab, tap on event.

![device-2019-12-19-000016](https://user-images.githubusercontent.com/6743693/71146262-90997600-21f2-11ea-814a-7e585076b0d4.png)
